### PR TITLE
Update for SDK 1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,8 @@ jobs:
   # build
   #
   # This job is run for all commits. It makes sure that: the source code
-  # is properly linted, the source code is properly formatted, the source
-  # can be compiled and built successfully, and the Docker image can be
-  # built successfully.
+  # is properly  formatted, the source can be compiled and built successfully,
+  # and the Docker image can be built successfully.
   #
   # This job does not publish any build artifacts.
   build:
@@ -39,9 +38,6 @@ jobs:
       - run:
           name: Install Vendored Dependencies
           command: make dep
-      - run:
-          name: Lint
-          command: make lint
       - run:
           name: Format
           command: |
@@ -58,6 +54,31 @@ jobs:
       - run:
           name: Build Docker Image
           command: make docker
+      - save_cache:
+          when: on_success
+          key: v1-vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
+          paths:
+            - vendor/
+
+  # lint
+  #
+  # This job runs linting on the project source files. It is kept as a separate
+  # job because it takes a while to run. Running this job in parallel speeds up
+  # the CI flow overall.
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
+            - v1-vendor-{{ checksum "Gopkg.toml" }}
+      - run:
+          name: Install Vendored Dependencies
+          command: make dep
+      - run:
+          name: Lint
+          command: make lint
       - save_cache:
           when: on_success
           key: v1-vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
@@ -163,10 +184,12 @@ workflows:
   build:
     jobs:
       - build
+      - lint
       - publish-edge:
           context: vapor-auto
           requires:
             - build
+            - lint
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Setup
+          command: |
+            go get -u golang.org/x/tools/cmd/goimports
       - restore_cache:
           keys:
             - v1-vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,72 +2,99 @@
 
 
 [[projects]]
+  digest = "1:d867dfa6751c8d7a435821ad3b736310c2ed68945d05b50fb9d23aee0540c8cc"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
-  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-  version = "v1.0.5"
+  pruneopts = "UT"
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
+  digest = "1:7f769a7ea697a8e50c8a79a829f53a469e3ca7b8e314434ea9d9a25ca8401cb7"
   name = "github.com/creasty/defaults"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a7e48e2230891fc7456c8ab918c424c5b06c3192"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:bc38c7c481812e178d85160472e231c5e1c9a7f5845d67e23ee4e706933c10d8"
+  name = "github.com/golang/mock"
+  packages = ["gomock"]
+  pruneopts = "UT"
+  revision = "c34cdb4725f4c3844d095133c6e40e448b86589b"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:ae0036fa14b41c52607c53fa072ef5045ec5f9013ed569e6a5fa19dd5e2ac89a"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  pruneopts = "UT"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
+  digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
   name = "github.com/patrickmn/go-cache"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
   version = "v2.1.0"
 
 [[projects]]
+  digest = "1:2e76a73cb51f42d63a2a1a85b3dc5731fd4faf6821b434bd0ef2c099186031d6"
   name = "github.com/rs/xid"
   packages = ["."]
-  revision = "2c7e97ce663ff82c49656bca3048df0fdd83c5f9"
-  version = "v1.2.0"
+  pruneopts = "UT"
+  revision = "15d26544def341f036c5f8dca987a4cbe575032c"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:48dd3703123d9877f695f41e36d5b8581ef7cd002e8e54c4edb7fbec5e65a23c"
   name = "github.com/soniah/gosnmp"
   packages = ["."]
-  revision = "39f440c6e3c2f59d2141ddf3e97195bcb2abecff"
+  pruneopts = "UT"
+  revision = "35d70ef6436030897babd670877f2d4a1748c249"
 
 [[projects]]
-  branch = "master"
+  digest = "1:718950f28a3902b3a3abf93c8cfca0ebfc8521748e432cc34c4220045a55f5ea"
   name = "github.com/vapor-ware/synse-sdk"
   packages = [
     "sdk",
     "sdk/errors",
     "sdk/health",
-    "sdk/policies"
+    "sdk/policies",
   ]
-  revision = "de65abac8043b5653fa0afb43f9f1e60baf8acf0"
+  pruneopts = "UT"
+  revision = "95a2deff1260171cbcd5d58a12b3cdbe6159b4e9"
+  version = "1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:bf033fb06435e52e54e920d172f72b11b2ea91e44b2b9a5e21e57a616590f9d7"
   name = "github.com/vapor-ware/synse-server-grpc"
   packages = ["go"]
-  revision = "8dc490fe19fb65f9b9ed3bc2e02621f098f5a887"
+  pruneopts = "UT"
+  revision = "5a6280c2ec33b2eb3781e7700ddfec04294bf3c6"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
+  pruneopts = "UT"
+  revision = "0709b304e793a5edb4a2c0145f281ecdc20838a4"
 
 [[projects]]
   branch = "master"
+  digest = "1:1427ef3c5200ade53e1569b34a7fd49dff8df0c2b3cdb9539a727f69ae5eddfa"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -76,20 +103,24 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
-  revision = "039a4258aec0ad3c79b905677cceeab13b296a77"
+  pruneopts = "UT"
+  revision = "161cd47e91fd58ac17490ef4d742dc98bb4cf60e"
 
 [[projects]]
   branch = "master"
+  digest = "1:34d379c4ad053c9b3930c98837f52130ac42de3a64d6fcc8bb33ceb404a55d85"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
-  revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
+  pruneopts = "UT"
+  revision = "8cf3aee429924738c56c34bb819c4ea8273fc434"
 
 [[projects]]
+  digest = "1:7509ba4347d1f8de6ae9be8818b0cd1abc3deeffe28aeaf4be6d4b6b5178d9ca"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -105,24 +136,30 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "UT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
+  digest = "1:077c1c599507b3b3e9156d17d36e1e61928ee9b53a5b420f10f28ebd4a0b275c"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "e92b116572682a5b432ddd840aeaba2a559eeff1"
+  pruneopts = "UT"
+  revision = "11092d34479b07829b72e10713b159248caf5dad"
 
 [[projects]]
+  digest = "1:74f4a872f90f363778088654a2edea7101d62e6fc0784945d38b0ef85e1828d8"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -138,7 +175,9 @@
     "internal",
     "internal/backoff",
     "internal/channelz",
+    "internal/envconfig",
     "internal/grpcrand",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
@@ -149,20 +188,27 @@
     "stats",
     "status",
     "tap",
-    "transport"
   ]
-  revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
-  version = "v1.13.0"
+  pruneopts = "UT"
+  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
+  version = "v1.14.0"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "baf5b960c6d5c62be2d5d7511836535ecb310dfcff443fb75171e9c5ecf6afb5"
+  input-imports = [
+    "github.com/Sirupsen/logrus",
+    "github.com/soniah/gosnmp",
+    "github.com/vapor-ware/synse-sdk/sdk",
+    "github.com/vapor-ware/synse-sdk/sdk/policies",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/vapor-ware/synse-sdk"
-  branch = "master"
+  version = "1.1.0"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := snmp
-PLUGIN_VERSION := 0.2.0-dev
+PLUGIN_VERSION := 1.0.0
 IMAGE_NAME     := vaporio/snmp-plugin
 
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2> /dev/null || true)
@@ -49,14 +49,6 @@ docker:  ## Build the docker image
 	docker build -f Dockerfile \
 		-t $(IMAGE_NAME):latest \
 		-t $(IMAGE_NAME):local .
-
-.PHONY: push
-push:
-	docker rmi vaporio/snmp-plugin:latest || true
-	docker build -f Dockerfile \
-		-t $(IMAGE_NAME):latest \
-		-t $(IMAGE_NAME):local .
-	docker push vaporio/snmp-plugin:latest
 
 .PHONY: fmt
 fmt:  ## Run goimports on all go files
@@ -118,8 +110,8 @@ help:  ## Print usage information
 .DEFAULT_GOAL := help
 
 .PHONY: all
-all: ## make clean build fmt lint test push
-	@$(MAKE) clean build fmt lint test push
+all: ## make clean build fmt lint test
+	@$(MAKE) clean build fmt lint test
 
 #
 # CI Targets

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CircleCI](https://circleci.com/gh/vapor-ware/synse-snmp-plugin.svg?style=shield)](https://circleci.com/gh/vapor-ware/synse-snmp-plugin)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fvapor-ware%2Fsynse-snmp-plugin.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fvapor-ware%2Fsynse-snmp-plugin?ref=badge_shield)
+![GitHub release](https://img.shields.io/github/release/vapor-ware/synse-snmp-plugin.svg)
 
 # Synse SNMP Plugin
 A general-purpose SNMP plugin for [Synse Server][synse-server].
@@ -12,27 +13,27 @@ set for that field.
 
 | Name | Description | Unit | Precision | Scaling Factor |
 | ---- | ----------- | ---- | --------- | -------------- |
-| current | An output type for current readings | amps | 3 | - |
-| frequency | An output type for frequency readings | hertz | 3 | - |
-| identity | An output type for identity readings | - | - | - |
-| va.power | An output type for power readings, in volt-amperes | volt-ampere | 3 | - |
-| watts.power | An output type for power readings, in watts | watts | 3 | - |
-| status | An output type for status readings | - | - | - |
-| temperature | An output type for temperature readings | degrees celsius | 3 | - |
-| voltage | An output type for voltage readings | volts | 3 | - |
+| `current` | An output type for current readings | amps | 3 | - |
+| `frequency` | An output type for frequency readings | hertz | 3 | - |
+| `identity` | An output type for identity readings | - | - | - |
+| `va.power` | An output type for power readings, in volt-amperes | volt-ampere | 3 | - |
+| `watts.power` | An output type for power readings, in watts | watts | 3 | - |
+| `status` | An output type for status readings | - | - | - |
+| `temperature` | An output type for temperature readings | degrees celsius | 3 | - |
+| `voltage` | An output type for voltage readings | volts | 3 | - |
 
 ### Device Handlers
 Device Handlers should be referenced by name.
 
 | Name | Description | Read | Write | Bulk Read |
 | ---- | ----------- | ---- | ----- | --------- |
-| current | A handler for the SNMP OIDs that report current | ✓ | ✗ | ✗ |
-| frequency | A handler for the SNMP OIDs that report frequency | ✓ | ✗ | ✗ |
-| identity | A handler for the SNMP-identity device | ✓ | ✗ | ✗ |
-| power | A handler for the SNMP OIDs that report power | ✓ | ✗ | ✗ |
-| status | A handler for the SNMP-status device | ✓ | ✗ | ✗ |
-| temperature | A handler for the SNMP OIDs that report temperature | ✓ | ✗ | ✗ |
-| voltage | A handler for the SNMP OIDs that report voltage | ✓ | ✗ | ✗ |
+| `current` | A handler for the SNMP OIDs that report current | ✓ | ✗ | ✗ |
+| `frequency` | A handler for the SNMP OIDs that report frequency | ✓ | ✗ | ✗ |
+| `identity` | A handler for the SNMP-identity device | ✓ | ✗ | ✗ |
+| `power` | A handler for the SNMP OIDs that report power | ✓ | ✗ | ✗ |
+| `status` | A handler for the SNMP-status device | ✓ | ✗ | ✗ |
+| `temperature` | A handler for the SNMP OIDs that report temperature | ✓ | ✗ | ✗ |
+| `voltage` | A handler for the SNMP OIDs that report voltage | ✓ | ✗ | ✗ |
 
 ### Write Values
 The SNMP plugin does not currently support writing to any devices.

--- a/snmp/servers/pxgms_ups.go
+++ b/snmp/servers/pxgms_ups.go
@@ -32,7 +32,7 @@ type PxgmsUps struct {
 // version:v3
 func NewPxgmsUps(data map[string]interface{}) (ups *PxgmsUps, err error) { // nolint: gocyclo
 
-	logger.Debug("NewPxgmUps start. data: %+v", data)
+	logger.Debugf("NewPxgmUps start. data: %+v", data)
 
 	// FIXME (etd): Sorta a hack just to get things moving, but adding in a check against
 	// the model here. There could probably be something at a higher level that checks this
@@ -41,7 +41,7 @@ func NewPxgmsUps(data map[string]interface{}) (ups *PxgmsUps, err error) { // no
 	// now only support one and only one model.
 	// We intend to be able to share SNMP MIBs across models and this won't work at all.
 	model := data["model"].(string)
-	logger.Debugf("model is: [%m]", model)
+	logger.Debugf("model is: [%s]", model)
 	if !strings.HasPrefix(model, "PXGMS UPS") {
 		return nil, fmt.Errorf("only PXGMS UPS models are currently supported")
 	}


### PR DESCRIPTION
Update the plugin dependencies to use SDK v1.1.0, enables tls/ssl support on the gRPC connection with Synse Server.

This also adds some updates to the README, bumps the plugin version for release, and updates the Makefile. It removes the `push` target because we should never be pushing the latest tag manually - that process is automated and the expectation is that latest is the latest stable release, not a development or edge release.