### PR TITLE
We need to remove /plugin/config.yml since it is the emulator config …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ LABEL maintainer="vapor@vapor.io"
 WORKDIR /plugin
 
 COPY --from=builder /go/src/github.com/vapor-ware/synse-snmp-plugin/build/plugin ./plugin
-COPY config.yml .
+# COPY config.yml .
+# TODO: We need to remove this copy since it's the emulator config.yml.
+# Copying here will cause deployments to fail since /plugin/config.yml gets
+# picked up before /etc/synse/plugin/config/config.yml which means that a
+# deploy to real hardware would use the emulator config.yml.
+# TODO: We will need to bring this back somewhow, as well as to fix the tests.
 
 CMD ["./plugin"]


### PR DESCRIPTION
…and it will get picked up in production before /etc/synse/plugin/config/config.yml which breaks all functionality.