### PR TITLE
bump golang image versions to 1.13

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -23,7 +23,7 @@ pipeline {
     stage('Vendor Dependencies') {
       agent {
         docker {
-          image 'vaporio/golang:1.11'
+          image 'vaporio/golang:1.13'
           reuseNode true
         }
       }
@@ -50,7 +50,7 @@ pipeline {
     stage('Lint') {
       agent {
         docker {
-          image 'vaporio/golang:1.11'
+          image 'vaporio/golang:1.13'
           reuseNode true
         }
       }
@@ -91,7 +91,7 @@ pipeline {
     stage('Build Release Artifacts') {
       agent {
         docker {
-          image 'vaporio/golang:1.11'
+          image 'vaporio/golang:1.13'
           reuseNode true
         }
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder Image
-FROM vaporio/golang:1.11 as builder
+FROM vaporio/golang:1.13 as builder
 WORKDIR /go/src/github.com/vapor-ware/synse-snmp-plugin
 COPY . .
 


### PR DESCRIPTION
This PR:
- bumps the version of the `vaporio/golang` image used in CI and the Dockerfile from 1.11 (deprecated) to 1.13

fixes #19 