### PR TITLE
Split out status-int and status-string.

### DIFF
--- a/devices/devices_test.go
+++ b/devices/devices_test.go
@@ -35,9 +35,13 @@ func CreateDevices(config *sdk.DeviceConfig, handler *sdk.DeviceHandler) ([]*sdk
 				{OutputType: outputs.WattsPower},
 				{OutputType: outputs.VAPower},
 			}
-		case "status":
+		case "status-int":
 			deviceOutputs = []*sdk.Output{
-				{OutputType: outputs.Status},
+				{OutputType: outputs.StatusInt},
+			}
+		case "status-string":
+			deviceOutputs = []*sdk.Output{
+				{OutputType: outputs.StatusString},
 			}
 		case "temperature":
 			deviceOutputs = []*sdk.Output{
@@ -195,9 +199,9 @@ func TestDevices(t *testing.T) { // nolint: gocyclo
 		}
 	}
 	// Check the total number of unique number of device kinds
-	if len(kinds) != 7 {
+	if len(kinds) != 8 {
 		t.Logf("found kinds: %v", kinds)
-		t.Fatalf("Expected 7 device kinds, got %d", len(kinds))
+		t.Fatalf("Expected 8 device kinds, got %d", len(kinds))
 	}
 
 	// Check the total number of device instances
@@ -235,8 +239,10 @@ func TestDevices(t *testing.T) { // nolint: gocyclo
 				deviceHandler = &SnmpIdentity
 			case "power":
 				deviceHandler = &SnmpPower
-			case "status":
-				deviceHandler = &SnmpStatus
+			case "status-int":
+				deviceHandler = &SnmpStatusInt
+			case "status-string":
+				deviceHandler = &SnmpStatusString
 			case "temperature":
 				deviceHandler = &SnmpTemperature
 			case "voltage":

--- a/devices/enumeration.go
+++ b/devices/enumeration.go
@@ -34,10 +34,12 @@ func TranslateEnumeration(result core.ReadResult, data map[string]interface{}) (
 			result.Data, result.Data)
 	}
 
+	// Key lookup to find the enumaration,
 	key := fmt.Sprintf("enumeration%d", resultInt)
 	translation, ok := data[key]
 	if !ok {
-		translation = "undefined" // No translation found. unknown is acually used in SNMP.
+		// Not found. Return something with the raw int.
+		translation = fmt.Sprintf("undefined%d", resultInt)
 	}
 	return fmt.Sprint(translation), nil
 }

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -23,9 +23,17 @@ var (
 		},
 	}
 
-	// Status describes readings with status outputs.
-	Status = sdk.OutputType{
-		Name: "status",
+	// StatusInt describes readings with status outputs where status is an
+	// integer. Status is a very generic output and avoids a plethora of more
+	// specific output types.
+	StatusInt = sdk.OutputType{
+		Name: "status-int",
+	}
+
+	// StatusString describes readings with status outputs where status is a
+	// string, for example an enumeration.
+	StatusString = sdk.OutputType{
+		Name: "status-string",
 	}
 
 	// WattsPower describes readings with power (watts) outputs.

--- a/plugin.go
+++ b/plugin.go
@@ -133,7 +133,8 @@ func main() {
 		&outputs.Identity,
 		&outputs.VAPower,
 		&outputs.WattsPower,
-		&outputs.Status,
+		&outputs.StatusInt,
+		&outputs.StatusString,
 		&outputs.Temperature,
 		&outputs.Voltage,
 	)
@@ -148,7 +149,8 @@ func main() {
 		&devices.SnmpFrequency,
 		&devices.SnmpIdentity,
 		&devices.SnmpPower,
-		&devices.SnmpStatus,
+		&devices.SnmpStatusInt,
+		&devices.SnmpStatusString,
 		&devices.SnmpTemperature,
 		&devices.SnmpVoltage,
 	)

--- a/snmp/mibs/ups_mib/ups_battery_table.go
+++ b/snmp/mibs/ups_mib/ups_battery_table.go
@@ -82,16 +82,27 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 		Devices: []*sdk.DeviceKind{},
 	}
 
-	// We will have "status", "voltage", "current", and "temperature" device kinds.
+	// We will have "status-int", "status-string", "voltage", "current", and "temperature" device kinds.
 	// There is probably a better way of doing this, but this just gets things to
 	// where they need to be for now.
-	statusKind := &sdk.DeviceKind{
-		Name: "status",
+	statusIntKind := &sdk.DeviceKind{
+		Name: "status-int",
 		Metadata: map[string]string{
 			"model": model,
 		},
 		Outputs: []*sdk.DeviceOutput{
-			{Type: "status"},
+			{Type: "status-int"},
+		},
+		Instances: []*sdk.DeviceInstance{},
+	}
+
+	statusStringKind := &sdk.DeviceKind{
+		Name: "status-string",
+		Metadata: map[string]string{
+			"model": model,
+		},
+		Outputs: []*sdk.DeviceOutput{
+			{Type: "status-string"},
 		},
 		Instances: []*sdk.DeviceInstance{},
 	}
@@ -130,7 +141,8 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 	}
 
 	cfg.Devices = []*sdk.DeviceKind{
-		statusKind,
+		statusIntKind,
+		statusStringKind,
 		voltageKind,
 		currentKind,
 		temperatureKind,
@@ -165,7 +177,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 		Location: snmpLocation,
 		Data:     deviceData,
 	}
-	statusKind.Instances = append(statusKind.Instances, device)
+	statusStringKind.Instances = append(statusStringKind.Instances, device)
 
 	// upsSecondsOnBattery --------------------------------------------------------
 	deviceData = map[string]interface{}{
@@ -185,7 +197,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 		Location: snmpLocation,
 		Data:     deviceData,
 	}
-	statusKind.Instances = append(statusKind.Instances, device)
+	statusIntKind.Instances = append(statusIntKind.Instances, device)
 
 	// upsEstimatedMinutesRemaining -----------------------------------------------
 	deviceData = map[string]interface{}{
@@ -205,7 +217,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 		Location: snmpLocation,
 		Data:     deviceData,
 	}
-	statusKind.Instances = append(statusKind.Instances, device)
+	statusIntKind.Instances = append(statusIntKind.Instances, device)
 
 	// upsEstimatedChargeRemaining ------------------------------------------------
 	deviceData = map[string]interface{}{
@@ -225,7 +237,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 		Location: snmpLocation,
 		Data:     deviceData,
 	}
-	statusKind.Instances = append(statusKind.Instances, device)
+	statusIntKind.Instances = append(statusIntKind.Instances, device)
 
 	// upsBatteryVoltage ----------------------------------------------------------
 	deviceData = map[string]interface{}{

--- a/snmp/mibs/ups_mib/ups_output_headers_table.go
+++ b/snmp/mibs/ups_mib/ups_output_headers_table.go
@@ -76,16 +76,27 @@ func (enumerator UpsOutputHeadersTableDeviceEnumerator) DeviceEnumerator(
 		Devices: []*sdk.DeviceKind{},
 	}
 
-	// We will have "status" and "frequency" device kinds.
+	// We will have "status-int", "status-string" and "frequency" device kinds.
 	// There is probably a better way of doing this, but this just gets things to
 	// where they need to be for now.
-	statusKind := &sdk.DeviceKind{
-		Name: "status",
+	statusIntKind := &sdk.DeviceKind{
+		Name: "status-int",
 		Metadata: map[string]string{
 			"model": model,
 		},
 		Outputs: []*sdk.DeviceOutput{
-			{Type: "status"},
+			{Type: "status-int"},
+		},
+		Instances: []*sdk.DeviceInstance{},
+	}
+
+	statusStringKind := &sdk.DeviceKind{
+		Name: "status-string",
+		Metadata: map[string]string{
+			"model": model,
+		},
+		Outputs: []*sdk.DeviceOutput{
+			{Type: "status-string"},
 		},
 		Instances: []*sdk.DeviceInstance{},
 	}
@@ -102,7 +113,8 @@ func (enumerator UpsOutputHeadersTableDeviceEnumerator) DeviceEnumerator(
 	}
 
 	cfg.Devices = []*sdk.DeviceKind{
-		statusKind,
+		statusIntKind,
+		statusStringKind,
 		frequencyKind,
 	}
 
@@ -139,7 +151,7 @@ func (enumerator UpsOutputHeadersTableDeviceEnumerator) DeviceEnumerator(
 		Location: snmpLocation,
 		Data:     deviceData,
 	}
-	statusKind.Instances = append(statusKind.Instances, device)
+	statusStringKind.Instances = append(statusStringKind.Instances, device)
 
 	// upsOutputFrequency --------------------------------------------------------
 	deviceData = map[string]interface{}{
@@ -180,7 +192,7 @@ func (enumerator UpsOutputHeadersTableDeviceEnumerator) DeviceEnumerator(
 		Location: snmpLocation,
 		Data:     deviceData,
 	}
-	statusKind.Instances = append(statusKind.Instances, device)
+	statusIntKind.Instances = append(statusIntKind.Instances, device)
 
 	devices = append(devices, cfg)
 	return devices, err

--- a/snmp/mibs/ups_mib/ups_output_table.go
+++ b/snmp/mibs/ups_mib/ups_output_table.go
@@ -21,7 +21,7 @@ func NewUpsOutputTable(snmpServerBase *core.SnmpServerBase) (
 		"UPS-MIB-UPS-Output-Table", // Table Name
 		".1.3.6.1.2.1.33.1.4.4",    // WalkOid
 		[]string{ // Column Names
-			"upsOutputLineIndex", // MIB says not accessable. Have seen it in walks.
+			"upsOutputLineIndex", // MIB says not accessible. Have seen it in walks.
 			"upsOutputVoltage",   // RMS Volts
 			"upsOutputCurrent",   // .1 RMS Amp
 			"upsOutputPower",     // Watts
@@ -78,16 +78,16 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 		Devices: []*sdk.DeviceKind{},
 	}
 
-	// We will have "status", "voltage", "current", and "temperature" device kinds.
+	// We will have "status-int", "voltage", "current", and "temperature" device kinds.
 	// There is probably a better way of doing this, but this just gets things to
 	// where they need to be for now.
-	statusKind := &sdk.DeviceKind{
-		Name: "status",
+	statusIntKind := &sdk.DeviceKind{
+		Name: "status-int",
 		Metadata: map[string]string{
 			"model": model,
 		},
 		Outputs: []*sdk.DeviceOutput{
-			{Type: "status"},
+			{Type: "status-int"},
 		},
 		Instances: []*sdk.DeviceInstance{},
 	}
@@ -126,7 +126,7 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 	}
 
 	cfg.Devices = []*sdk.DeviceKind{
-		statusKind,
+		statusIntKind,
 		voltageKind,
 		currentKind,
 		powerKind,
@@ -137,7 +137,6 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 		// deviceData gets shimmed into the DeviceConfig for each synse device.
 		// It varies slightly for each device below.
 		deviceData := map[string]interface{}{
-			//"info":       fmt.Sprintf("upsOutputVoltage%d", i),
 			"base_oid":   table.Rows[i].BaseOid,
 			"table_name": table.Name,
 			"row":        fmt.Sprintf("%d", i),
@@ -159,7 +158,6 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 
 		// upsOutputCurrent ----------------------------------------------------------
 		deviceData = map[string]interface{}{
-			//"info":       fmt.Sprintf("upsOutputCurrent%d", i),
 			"base_oid":   table.Rows[i].BaseOid,
 			"table_name": table.Name,
 			"row":        fmt.Sprintf("%d", i),
@@ -181,7 +179,6 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 
 		// upsOutputPower -------------------------------------------------------------
 		deviceData = map[string]interface{}{
-			//"info":       fmt.Sprintf("upsOutputPower%d", i),
 			"base_oid":   table.Rows[i].BaseOid,
 			"table_name": table.Name,
 			"row":        fmt.Sprintf("%d", i),
@@ -203,7 +200,6 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 
 		// upsOutputPercentLoad -------------------------------------------------------
 		deviceData = map[string]interface{}{
-			//"info":       fmt.Sprintf("upsOutputPercentLoad%d", i),
 			"base_oid":   table.Rows[i].BaseOid,
 			"table_name": table.Name,
 			"row":        fmt.Sprintf("%d", i),
@@ -220,7 +216,7 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 			Location: snmpLocation,
 			Data:     deviceData,
 		}
-		statusKind.Instances = append(statusKind.Instances, device)
+		statusIntKind.Instances = append(statusIntKind.Instances, device)
 	}
 
 	devices = append(devices, cfg)


### PR DESCRIPTION
Fixes: https://github.com/vapor-ware/synse-snmp-plugin/issues/29

The main thing this fixes is that sometimes device type/kind status was an enumeration (string) and sometimes it was a number (which was emitted as a string when it should not have been).

This makes a clear differentiation for the client by deprecating status and using status-int and status-string. We can add status-double later as needed.

Status is kind of a lame sensor type, because what is it? It's very generic. On the other hand it avoids adding a plethora of sensor types such as:
- time-in-seconds
- time-in-minutes
- percent-charge-remaining
- percent-load
- count (number of)
- specific enumerations
... Which the caller would then have to handle (even if a new device type/kind is added in a future version of synse - requiring a corresponding client side update). So status was an attempt to simplify.

Probably want more testing around this in the future. I can say that about everything.

```
For the SNMP UPS MIB:

status => currently (changed)

upsBatteryStatus => Enumeration (String)
upsSecondsOnBattery => Int
upsEstimatedMinutesRemaining => Int
upsEstimatedChargeRemaining => Int
upsOutputSource => Enumeration (String)
upsOutputNumLines => Int
upsOutputPercentLoad0 => Int
upsOutputPercentLoad1 => Int
upsOutputPercentLoad2 => Int
```