### PR TITLE
Remove trace. Partial fix for #32.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ github-tag:  ## Create and push a tag with the current plugin version
 .PHONY: lint
 lint:  ## Lint project source files
 ifndef HAS_LINT
-	$(shell curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $$(go env GOPATH)/bin v1.18.0)
+	$(shell curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $$(go env GOPATH)/bin v1.21.0)
 endif
 	golangci-lint run --deadline=5m
 

--- a/snmp/servers/pxgms_ups.go
+++ b/snmp/servers/pxgms_ups.go
@@ -32,14 +32,14 @@ type PxgmsUps struct {
 // version:v3
 func NewPxgmsUps(data map[string]interface{}) (ups *PxgmsUps, err error) { // nolint: gocyclo
 
-	logger.Debugf("NewPxgmUps start. data: %+v", data)
-
 	// FIXME (etd): Sorta a hack just to get things moving, but adding in a check against
 	// the model here. There could probably be something at a higher level that checks this
 	// and initializes the right stuff based on the specified model.
 	// TODO: File a ticket on this. Checking against the model is ruining SNMP. Any MIB can
 	// now only support one and only one model.
 	// We intend to be able to share SNMP MIBs across models and this won't work at all.
+	// (mhink): The SNMP server level factory is NYI due to other oblications. This will allow sharing MIBs.
+	// Ticket is here: https://github.com/vapor-ware/synse-snmp-plugin/issues/10
 	model := data["model"].(string)
 	logger.Debugf("model is: [%s]", model)
 	if !strings.HasPrefix(model, "PXGMS UPS") {


### PR DESCRIPTION
Partial fix for https://github.com/vapor-ware/synse-snmp-plugin/issues/32
Update linter.
Added notes on the NYI SNMP Server Factory.