### PR TITLE
Update deps. Synse SDK v 1.2.1.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,17 @@ module github.com/vapor-ware/synse-snmp-plugin
 go 1.13
 
 require (
-	github.com/creasty/defaults v1.3.0
-	github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129
-	github.com/golang/protobuf v1.3.2
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2
-	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/rs/xid v1.2.1
+	github.com/creasty/defaults v1.3.0 // indirect
+	github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/soniah/gosnmp v1.22.1-0.20190605023908-e1cc1327e769
-	github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190924003814-b79b1b2772a6
-	github.com/vapor-ware/synse-server-grpc v0.0.2-0.20181022185647-3bc0b24b2bfb
-	golang.org/x/net v0.0.0-20190918130420-a8b05e9114ab
-	golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13
-	golang.org/x/text v0.3.2
-	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	google.golang.org/genproto v0.0.0-20190916214212-f660b8655731
-	google.golang.org/grpc v1.23.1
-	gopkg.in/yaml.v2 v2.2.2
+	github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191211183457-d90486afd9d7
+	golang.org/x/net v0.0.0-20190918130420-a8b05e9114ab // indirect
+	golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
+	google.golang.org/genproto v0.0.0-20190916214212-f660b8655731 // indirect
+	google.golang.org/grpc v1.23.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,9 @@ github.com/creasty/defaults v1.2.1/go.mod h1:CIEEvs7oIVZm30R8VxtFJs+4k201gReYyuY
 github.com/creasty/defaults v1.3.0 h1:uG+RAxYbJgOPCOdKEcec9ZJXeva7Y6mj/8egdzwmLtw=
 github.com/creasty/defaults v1.3.0/go.mod h1:CIEEvs7oIVZm30R8VxtFJs+4k201gReYyuYHJxZc68I=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -18,9 +20,11 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
@@ -32,10 +36,12 @@ github.com/soniah/gosnmp v1.22.1-0.20190605023908-e1cc1327e769/go.mod h1:DuEpAS0
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20181023133336-fc11f0f3f375/go.mod h1:1L31x32IYQ6kvIkT0SZ06jRHy6/OR1fNoFhyQhcBowI=
 github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190924003814-b79b1b2772a6 h1:YIjqCQxNJZqJPnUWUM0b8kLbO5wXBRV3I1Vi/WsxHwk=
 github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190924003814-b79b1b2772a6/go.mod h1:6R9m4O+qwfCtVrTW0gdvdBuuiEg6X/Z6SzjbWtd2GCI=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191211183457-d90486afd9d7 h1:5CDEqEa64RVN6UhAndP/96WnwBnEJxczWeccHMft9Oo=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191211183457-d90486afd9d7/go.mod h1:6R9m4O+qwfCtVrTW0gdvdBuuiEg6X/Z6SzjbWtd2GCI=
 github.com/vapor-ware/synse-server-grpc v0.0.2-0.20181022185647-3bc0b24b2bfb h1:6b0dPcxyTcnEjG7ONWD36+82wPsAm5O6QGaIIgI5U8M=
 github.com/vapor-ware/synse-server-grpc v0.0.2-0.20181022185647-3bc0b24b2bfb/go.mod h1:66oRQ1KV/ZevAiiXbSUjRbx/h91xG/ArE/V39Jh872I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -88,6 +94,7 @@ google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9M
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.1 h1:q4XQuHFC6I28BKZpo6IYyb3mNO+l7lSOxRuYTCiDfXk=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
Going to roll this and https://github.com/vapor-ware/synse-snmp-plugin/pull/36 up with the Main SNMP PR here: https://github.com/vapor-ware/synse-snmp-plugin/pull/35.

This is just a placeholder for the diff. 

This is what I did:

```
Created a 1.2.1 synse-sdk release off master through the github ui
- https://help.github.com/en/github/administering-a-repository/creating-releases

# Update deps.
go mod tidy

# Update synse-sdk dep.
go get github.com/vapor-ware/synse-sdk@1.2.1

# Partial diff. 
# d90486afd9d7 is the 1.2.1 release head commit.
# 20191211 is the date of the head commit.
# 183457 is ? (maybe hours, minutes, seconds in some time zone?)
-       github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190924003814-b79b1b2772a6
-       github.com/vapor-ware/synse-server-grpc v0.0.2-0.20181022185647-3bc0b24b2bfb
+       github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191211183457-d90486afd9d7
```