### PR TITLE
use built-in watt type instead of custom watts type

### DIFF
--- a/pkg/devices/power.go
+++ b/pkg/devices/power.go
@@ -3,7 +3,6 @@ package devices
 import (
 	"github.com/vapor-ware/synse-sdk/sdk"
 	"github.com/vapor-ware/synse-sdk/sdk/output"
-	"github.com/vapor-ware/synse-snmp-plugin/pkg/outputs"
 )
 
 // SnmpPower is the handler for SNMP OIDs that report power.
@@ -30,7 +29,7 @@ func SnmpPowerRead(device *sdk.Device) (readings []*output.Reading, err error) {
 
 	// Create the reading.
 	// FIXME (etd): differentiate between watts/VA
-	reading := outputs.WattsPower.MakeReading(resultFloat)
+	reading := output.Watt.MakeReading(resultFloat)
 
 	readings = []*output.Reading{reading}
 	return readings, nil

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -3,17 +3,6 @@ package outputs
 import "github.com/vapor-ware/synse-sdk/sdk/output"
 
 var (
-	// WattsPower describes readings with power (watts) outputs.
-	WattsPower = output.Output{
-		Name:      "watts",
-		Type:      "power",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name:   "watts",
-			Symbol: "W",
-		},
-	}
-
 	// VAPower describes readings with power (volt-ampere) outputs.
 	VAPower = output.Output{
 		Name:      "volt-ampere",

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -22,7 +22,6 @@ func MakePlugin() *sdk.Plugin {
 	err = plugin.RegisterOutputs(
 		&outputs.Identity,
 		&outputs.VAPower,
-		&outputs.WattsPower,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This PR:
- updates the plugin to remove the custom "watts" output type in favor of using the "watt" output type built-in to the SDK.