### PR TITLE
various small updates for v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM vaporio/golang:1.13 as builder
 #
 # Final Image
 #
-FROM scratch
+FROM vaporio/scratch-ish:1.0.0
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.name="vaporio/snmp-plugin" \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := snmp
-PLUGIN_VERSION := 3.0.0
+PLUGIN_VERSION := 3.0.0-alpha.1
 IMAGE_NAME     := vaporio/snmp-plugin
 BIN_NAME       := synse-snmp-plugin
 
@@ -37,6 +37,11 @@ clean:  ## Remove temporary files
 .PHONY: deploy
 deploy:  ## Run a local deployment of the plugin with Synse Server
 	docker-compose -f compose.yml up -d
+
+.PHONY: dep
+dep:  ## Verify and tidy gomod dependencies
+	go mod verify
+	go mod tidy
 
 .PHONY: docker
 docker:  ## Build the docker image

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200116192645-2f6842d278ad h1:LLwxCKM51Fu98PQpGpVquotx9NnVkI+qMebiW/vs52k=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200116192645-2f6842d278ad/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
 github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200117173641-274aae69c3e8 h1:VbbtTha0xrnjXzVps1HGFK2iREN88xlU3MVfTRsGSKE=
 github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200117173641-274aae69c3e8/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4 h1:1ksn9Jm2+3xi8lQcm+a1/abs3wG2iGV7mTHRejCzqmY=


### PR DESCRIPTION
This PR:
- updates version to 3.0.0-alpha.1
- adds make target
- uses vapor scratch image as base to make k8s probe checks easier
- tidies deps