### PR TITLE
bugfix: prevent passphrase leak on device config dump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/soniah/gosnmp v1.22.0
 	github.com/stretchr/testify v1.4.0
-	github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200129174706-5981ecb3e8b6
+	github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200204232146-14e1d68cde9e
 )

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200129174706-5981ecb3e8b6 h1:0Atct3TudCPRG24GIf0CTdVbACU9C4GUv9B9SwcKO9M=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200129174706-5981ecb3e8b6/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200204232146-14e1d68cde9e h1:RsmewjFIiVc1qnV7fXwwpqk+C9LuWtWRcX/OJcVO6Sw=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200204232146-14e1d68cde9e/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4 h1:1ksn9Jm2+3xi8lQcm+a1/abs3wG2iGV7mTHRejCzqmY=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4/go.mod h1:66oRQ1KV/ZevAiiXbSUjRbx/h91xG/ArE/V39Jh872I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/snmp/core/util.go
+++ b/pkg/snmp/core/util.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-sdk/sdk/utils"
 )
 
 // This file contains utility functions. In the future we could put them in
@@ -22,20 +23,41 @@ func CopyMapStringInterface(m map[string]interface{}) map[string]interface{} {
 // DumpDeviceConfigs to the log.
 func DumpDeviceConfigs(deviceConfigs []*config.DeviceProto) {
 	if deviceConfigs == nil {
-		log.Infof("No Device prototype Configs to dump\n")
+		log.Infof("[snmp] no device prototype configs to dump")
 		return
 	}
-	log.Infof("Found %d device prototype configs.\n", len(deviceConfigs))
-	for i := 0; i < len(deviceConfigs); i++ {
-		log.Infof("deviceProto[%d]: %T: %+v\n", i, deviceConfigs[i], deviceConfigs[i])
-		//logger.Infof("deviceConfig[%d].Devices: %T: %+v", i, deviceConfigs[i].Devices, deviceConfigs[i].Devices)
-		//devices := deviceConfigs[i].Devices
-		instances := deviceConfigs[i].Instances
-		for j := 0; j < len(instances); j++ {
-			log.Infof("deviceProto[%d].Instances[%d]: %T: %+v", i, j,
-				instances[j], instances[j])
 
-			log.Infof("deviceProto[%d].Instances[%d].Output: %+v", i, j, instances[j].Output)
+	log.WithField("count", len(deviceConfigs)).Info("[snmp] found device prototype configs")
+	for i := 0; i < len(deviceConfigs); i++ {
+		proto := deviceConfigs[i]
+		log.WithFields(log.Fields{
+			"idx":           i,
+			"instances":     len(proto.Instances),
+			"transforms":    len(proto.Transforms),
+			"write timeout": proto.WriteTimeout,
+			"handler":       proto.Handler,
+			"tags":          proto.Tags,
+			"type":          proto.Type,
+			"context":       utils.RedactPasswords(proto.Context),
+			"data":          utils.RedactPasswords(proto.Data),
+		}).Info("[snmp] dumping device prototype config")
+
+		for j := 0; j < len(proto.Instances); j++ {
+			instance := proto.Instances[j]
+			log.WithFields(log.Fields{
+				"idx":           j,
+				"prototype idx": i,
+				"write timeout": instance.WriteTimeout,
+				"transforms":    len(instance.Transforms),
+				"type":          instance.Type,
+				"tags":          instance.Tags,
+				"handler":       instance.Handler,
+				"info":          instance.Info,
+				"alias":         instance.Alias,
+				"output":        instance.Output,
+				"context":       utils.RedactPasswords(instance.Context),
+				"data":          utils.RedactPasswords(instance.Data),
+			}).Info("[snmp] dumping device instance config")
 		}
 	}
 }


### PR DESCRIPTION
This PR:
- updates logging so device proto/instance config dumps do not leak passphrases

This PR will also need an SDK update for https://github.com/vapor-ware/synse-sdk/pull/451 when that lands.

fixes #45 