### PR TITLE
docker: update base images to vaporio/foundation:bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 #
 # Builder Image
 #
-FROM vaporio/golang:1.13 as builder
+FROM vaporio/foundation:bionic as builder
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates
 
 #
 # Final Image

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@
 # to exec into a contain and dig into whatever may be going on inside.
 #
 
-FROM vaporio/foundation:xenial
+FROM vaporio/foundation:bionic
 
 WORKDIR /synse
 


### PR DESCRIPTION
This PR:
- updates the docker base images from `vaporio/foundation:xenial` to `vaporio/foundation:bionic`