### PR TITLE
First pass at fixing CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,109 +1,44 @@
 #!/usr/bin/env groovy
 
-pipeline {
 
-  agent {
-    label 'golang-alpha'
-  }
+// Include this shared CI repository to load script helpers and libraries.
+library identifier: 'vapor@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+  remote: 'https://github.com/vapor-ware/ci-shared.git',
+  credentialsId: 'vio-bot-gh'])
 
-  environment {
-    IMAGE_NAME = 'vaporio/snmp-plugin'
-  }
-
-  stages {
-    stage('Checkout') {
-      steps {
-        checkout scm
-      }
-    }
-
-    stage('Checks') {
-      parallel {
-
-        // Run tests on project source code.
-        // These tests run very differently when run from the Makefile and in CI.
-        // From the Makefile we start up the emulator in a container and expose port 1024
-        // on the host. The tests run on the host and connect through port 1024.
-        // Here we start up the emulator in a container and expose port 1024 on the host.
-        // The tests run in a golang container and connect to the exposed port 1024 on the host.
-        // This could cause problems with parallel builds, but it is a place to start.
-        //
-        // TODO (etd): Disabling this for now. The v3 branch uses a newer CI pattern that runs
-        //   in Kubernetes, so the docker build/networking assumptions here will not work. Will
-        //   need to spend some time thinking through what the best pattern would be to achieve
-        //   the needs of this test environment for the new CI setup.
-        //stage('Test') {
-        //  steps {
-        //    // Critical section to avoid container name collisions.
-        //    lock('Test') {
-        //      script {
-        //        // Build the SNMP emulator image.
-        //        sh 'docker build -t emulator_snmp-emulator-ups emulator'
-
-        //        // Start the SNMP emulator.
-        //        docker.image('emulator_snmp-emulator-ups:latest').withRun(
-        //          "-m 1024MB -p 1024:1024/udp --name snmp-emulator-ups", // args
-        //          "./start_snmp_emulator.sh ./data 1024 snmp-emulator-ups.log" // command
-        //          ) { se ->
-
-        //          // Stand up a container to run the tests. Put it on the host network.
-        //          docker.image('vaporio/golang:1.13').inside("--network=host") { testContainer ->
-        //            sh 'go test -cover -v ./...'
-        //          } // end testContainer
-        //        } // end emulator container
-        //      } // end script
-        //    } // end lock
-        //  } // end steps
-        //} // end stage
-
-        stage('Lint') {
-          steps {
-            container('golang') {
-              sh 'golint -set_exit_status ./pkg/...'
-            }
-          }
-        }
-
-        stage('Snapshot Build') {
-          steps {
-            container('golang') {
-              sh 'goreleaser release --debug --snapshot --skip-publish --rm-dist'
-            }
-          }
-        }
-      }
-    }
-
-    // Build the image with the 'edge' tag and publish it to DockerHub. This
-    // should only be run on the master branch (e.g. PR merge)
-    stage('Publish Latest') {
-      when {
-        branch 'master'
-      }
-      steps {
-        container('golang') {
-          withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-            sh 'docker push ${IMAGE_NAME}:latest'
-          }
-        }
-      }
-    }
-
-    stage('Tagged Release') {
-      when {
-        buildingTag()
-      }
-      environment {
-        GITHUB_TOKEN = credentials('vio-bot-gh-token')
-      }
-      steps {
-        container('golang') {
-          withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-            sh 'goreleaser release --debug --rm-dist'
-          }
-        }
-      }
-    }
-
-  }
-}
+golangPipeline([
+  "image": "vaporio/synse-snmp-plugin",
+  "podTemplate": """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    jenkins/job: synse-snmp-plugin
+spec:
+  containers:
+  - name: go
+    image: vaporio/jenkins-agent-golang:latest
+    command:
+    - cat
+    tty: true
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 998
+    volumeMounts:
+    - name: docker-sock
+      mountPath: /var/run/docker.sock
+    - name: docker-bin
+      mountPath: /usr/bin/docker
+  - name: emulator
+    image: lazypower/snmp-emulator:latest
+    tty: true
+  volumes:
+  - name: docker-sock
+    hostPath:
+      path: /var/run/docker.sock
+  - name: docker-bin
+    hostPath:
+      path: /usr/bin/docker
+"""
+])

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,15 @@ help:  ## Print usage information
 
 .DEFAULT_GOAL := help
 
+.PHONY: test
+test: ## Run all tests
+	go test -cover ./...
 
 
 # FIXME: try to streamline the below
 
-.PHONY: test
-test:  ## Run all tests
+.PHONY: old-test
+old-test:  ## Run all tests
 	# Start the SNMP emulator in a docker container in the background.
 	# Tests run on the local machine.
 	docker-compose -f ./emulator/test_snmp.yml down || true


### PR DESCRIPTION
Some notes about this as it's a long-tail of work.

- Leverages an ad-hoc pipeline constructed of multiple agents
- Uses the K8s pattern to declare a sidecar process w/ the emulator required to validate the SNMP Mibs
- Uses a "one-off" emulator build that I assembled from the `emulator` directory in the project and pushed to my namespace, This should not be the final image :)
- The production build process may need more attention, as the docker build/publish steps were not exercised.

In addition to the above, the golang-alpha builder is going to go away, so this is incomplete as written, but the validation step was done and I needed a means to start the conversation for a larger fix.