### PR TITLE
ci: fix bug in jenkins config (incorrect image name)

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -2,43 +2,45 @@
 
 
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@master', retriever: modernSCM(
-  [$class: 'GitSCMSource',
+library identifier: 'vapor@master', retriever: modernSCM([
+  $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
-  credentialsId: 'vio-bot-gh'])
+  credentialsId: 'vio-bot-gh',
+])
+
 
 golangPipeline([
-  "image": "vaporio/synse-snmp-plugin",
-  "podTemplate": """
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    jenkins/job: synse-snmp-plugin
-spec:
-  containers:
-  - name: go
-    image: vaporio/jenkins-agent-golang:latest
-    command:
-    - cat
-    tty: true
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 998
-    volumeMounts:
-    - name: docker-sock
-      mountPath: /var/run/docker.sock
-    - name: docker-bin
-      mountPath: /usr/bin/docker
-  - name: emulator
-    image: lazypower/snmp-emulator:latest
-    tty: true
-  volumes:
-  - name: docker-sock
-    hostPath:
-      path: /var/run/docker.sock
-  - name: docker-bin
-    hostPath:
-      path: /usr/bin/docker
-"""
+  'image': 'vaporio/snmp-plugin',
+  'podTemplate': """
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      labels:
+        jenkins/job: synse-snmp-plugin
+    spec:
+      containers:
+      - name: go
+        image: vaporio/jenkins-agent-golang:latest
+        command:
+        - cat
+        tty: true
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 998
+        volumeMounts:
+        - name: docker-sock
+          mountPath: /var/run/docker.sock
+        - name: docker-bin
+          mountPath: /usr/bin/docker
+      - name: emulator
+        image: lazypower/snmp-emulator:latest
+        tty: true
+      volumes:
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: docker-bin
+        hostPath:
+          path: /usr/bin/docker
+  """,
 ])


### PR DESCRIPTION
This PR:
- fixes a bug in jenkins config where the image name was incorrect
- formats/indents jenkins config for consistency


I noticed that the CI build in master had failed and discovered that it was because the incorrect image name was specified (`vaporio/synse-snmp-plugin`, but should be [`vaporio/snmp-plugin`](https://hub.docker.com/repository/docker/vaporio/snmp-plugin))