### PR TITLE
Exit if we fail to initialize the UPS data.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,23 +78,21 @@ help:  ## Print usage information
 
 .DEFAULT_GOAL := help
 
+# This test recipe probably is probably what ci is hooking into now? It's hard to tell.
+# You can't run tests on a dev box like this anymore without standing up the emulator first.
 .PHONY: test
 test: ## Run all tests
-	go test -cover ./...
+	go test -cover ./... || exit
 
 
 # FIXME: try to streamline the below
 
-.PHONY: old-test
-old-test:  ## Run all tests
+.PHONY: test-dev-box
+test-dev-box:  ## Run all tests on a dev box.
 	# Start the SNMP emulator in a docker container in the background.
 	# Tests run on the local machine.
 	docker-compose -f ./emulator/test_snmp.yml down || true
 	docker-compose -f ./emulator/test_snmp.yml build
 	docker-compose -f ./emulator/test_snmp.yml up -d
-	go test -cover ./... || (echo TESTS FAILED $$?; docker-compose -f ./emulator/test_snmp.yml kill; exit 1)
+	go test -cover -v ./... || (echo TESTS FAILED $$?; docker-compose -f ./emulator/test_snmp.yml kill; exit 1)
 	docker-compose -f ./emulator/test_snmp.yml down
-
-.PHONY: test-local
-test-local: ## Test with a local emulator (stand it up yourself)
-	go test -cover -v ./... || exit

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"fmt"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
@@ -61,7 +62,8 @@ func deviceEnumerator(data map[string]interface{}) (deviceConfigs []*config.Devi
 	log.Info("[snmp] initializing UPS")
 	pxgmsUps, err := servers.NewPxgmsUps(data)
 	if err != nil {
-		return nil, err
+		log.WithError(err).Error("Unable to initialize PxgmsUps")
+		os.Exit(1)
 	}
 	log.Info("[snmp] UPS initialized")
 

--- a/pkg/snmp/core/client.go
+++ b/pkg/snmp/core/client.go
@@ -77,6 +77,7 @@ type DeviceConfig struct {
 	Endpoint           string              // Endpoint of the SNMP server to connect to.
 	ContextName        string              // Context name for SNMP V3 messages.
 	Timeout            time.Duration       // Timeout for the SNMP query.
+	Retries            int                 // The number of retries on the connection.
 	SecurityParameters *SecurityParameters // SNMP V3 security parameters.
 	Port               uint16              // UDP port to connect to.
 }
@@ -121,6 +122,7 @@ func NewDeviceConfig(
 		SecurityParameters: securityParameters,
 		ContextName:        contextName,
 		Timeout:            time.Duration(30) * time.Second,
+		Retries:            3,
 	}, nil
 }
 
@@ -410,6 +412,7 @@ func (client *SnmpClient) createGoSNMP() (*gosnmp.GoSNMP, error) {
 			PrivacyPassphrase:        client.DeviceConfig.SecurityParameters.PrivacyPassphrase,
 		},
 		ContextName: client.DeviceConfig.ContextName,
+		Retries:     client.DeviceConfig.Retries,
 	}
 
 	// Connect

--- a/pkg/snmp/servers/pxgms_ups.go
+++ b/pkg/snmp/servers/pxgms_ups.go
@@ -37,7 +37,7 @@ func NewPxgmsUps(data map[string]interface{}) (ups *PxgmsUps, err error) { // no
 	// TODO: File a ticket on this. Checking against the model is ruining SNMP. Any MIB can
 	// now only support one and only one model.
 	// We intend to be able to share SNMP MIBs across models and this won't work at all.
-	// (mhink): The SNMP server level factory is NYI due to other oblications. This will allow sharing MIBs.
+	// (mhink): The SNMP server level factory is NYI due to other obligations. This will allow sharing MIBs.
 	// Ticket is here: https://github.com/vapor-ware/synse-snmp-plugin/issues/10
 	model := data["model"].(string)
 	log.Debugf("model is: [%s]", model)

--- a/pkg/snmp/servers/pxgms_ups_test.go
+++ b/pkg/snmp/servers/pxgms_ups_test.go
@@ -29,3 +29,26 @@ func TestPxgmsUps(t *testing.T) {
 	// TODO: Need to do more with this, but at least exercises the code for now.
 	t.Logf("pxgmsUps: %+v", pxgmsUps)
 }
+
+// TestPxgmsUpsInitializationFailure tests that we get an error when we cannot initialize the UPS MIB.
+// This test uses an auth failure to fail initialization.
+func TestPxgmsUpsInitializationFailure(t *testing.T) {
+	t.Log("TestPxgmUpsInitializationFailure start")
+	t.Logf("t: %+v", t)
+
+	data := make(map[string]interface{})
+	data["contextName"] = "public"
+	data["endpoint"] = "127.0.0.1"
+	data["userName"] = "simulator"
+	data["privacyProtocol"] = "AES"
+	data["privacyPassphrase"] = "incorrect_password"
+	data["port"] = 1024
+	data["authenticationProtocol"] = "SHA"
+	data["authenticationPassphrase"] = "incorrect_authentication"
+	data["model"] = "PXGMS UPS + EATON 93PM"
+	data["version"] = "v3"
+
+	_, err := NewPxgmsUps(data)
+	assert.Error(t, err)
+	assert.Equal(t, "Incoming packet is not authentic, discarding", err.Error())
+}


### PR DESCRIPTION
We're seeing poor connectivity in Edens and bad creds in Woodwin. If the plugin cannot get initialization data, no SNMP devices will ever show up in the scan, so fail hard and let k8 try again.

This makes problems more obvious.