### PR TITLE
Add support for APC Galaxy UPS. Fix #10.

### DIFF
--- a/pkg/options.go
+++ b/pkg/options.go
@@ -60,15 +60,15 @@ func deviceEnumerator(data map[string]interface{}) (deviceConfigs []*config.Devi
 	// Load the MIB from the configuration still.
 	// Factory class for initializing servers via config is TODO:
 	log.Info("[snmp] initializing UPS")
-	pxgmsUps, err := servers.NewPxgmsUps(data)
+	snmpServer, err := servers.CreateSnmpServer(data)
 	if err != nil {
-		log.WithError(err).Error("Unable to initialize PxgmsUps")
+		log.WithError(err).Error("Unable to initialize SnmpServer")
 		os.Exit(1)
 	}
 	log.Info("[snmp] UPS initialized")
 
 	// First get a map of each OID to each device instance.
-	oidMap, oidList, err := mapOidsToInstances(pxgmsUps.DeviceConfigs)
+	oidMap, oidList, err := mapOidsToInstances(snmpServer.DeviceConfigs)
 	if err != nil {
 		log.WithError(err).Error("[snmp] failed mapping OIDs to instances")
 		return nil, err
@@ -92,6 +92,6 @@ func deviceEnumerator(data map[string]interface{}) (deviceConfigs []*config.Devi
 	}
 
 	// Dump SNMP device configurations.
-	core.DumpDeviceConfigs(pxgmsUps.DeviceConfigs)
-	return pxgmsUps.DeviceConfigs, nil
+	core.DumpDeviceConfigs(snmpServer.DeviceConfigs)
+	return snmpServer.DeviceConfigs, nil
 }

--- a/pkg/snmp/servers/galaxy_ups.go
+++ b/pkg/snmp/servers/galaxy_ups.go
@@ -9,12 +9,12 @@ import (
 	mibs "github.com/vapor-ware/synse-snmp-plugin/pkg/snmp/mibs/ups_mib"
 )
 
-// PxgmsUps represents the PXGMS UPS + EATON 93PM SNMP Server.
-type PxgmsUps struct {
+// GalaxyUps represents the Galaxy VM 180 kVA SNMP Server.
+type GalaxyUps struct {
 	*SnmpServer // base class.
 }
 
-// NewPxgmsUps creates the PxgmsUps structure.
+// NewGalaxyUps creates the GalaxyUps structure.
 // Sample data that works with the emulator:
 // contextName:public
 // endpoint:127.0.0.1
@@ -26,13 +26,13 @@ type PxgmsUps struct {
 // authenticationPassphrase:auctoritas
 // model:PXGMS UPS + EATON 93PM
 // version:v3
-func NewPxgmsUps(data map[string]interface{}) (ups *PxgmsUps, err error) { // nolint: gocyclo
+func NewGalaxyUps(data map[string]interface{}) (ups *GalaxyUps, err error) { // nolint: gocyclo
 
-	// Parameter check against data["model"]
+	// Parameter check against the data["model"].
 	model := data["model"].(string)
 	log.Debugf("model is: [%s]", model)
-	if !strings.HasPrefix(model, "PXGMS UPS") {
-		return nil, fmt.Errorf("only PXGMS UPS models are currently supported")
+	if !strings.HasPrefix(model, "Galaxy VM") {
+		return nil, fmt.Errorf("only Galaxy UPS models are currently supported")
 	}
 
 	// Create the SNMP DeviceConfig,
@@ -81,7 +81,7 @@ func NewPxgmsUps(data map[string]interface{}) (ups *PxgmsUps, err error) { // no
 	}
 
 	// Set up the object.
-	return &PxgmsUps{
+	return &GalaxyUps{
 		&SnmpServer{
 			SnmpServerBase: snmpServerBase,
 			UpsMib:         upsMib,

--- a/pkg/snmp/servers/galaxy_ups_test.go
+++ b/pkg/snmp/servers/galaxy_ups_test.go
@@ -1,0 +1,54 @@
+package servers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGalaxyUps is the first GalaxyUps test.
+func TestGalaxyUps(t *testing.T) {
+	t.Log("TestGalaxyUps start")
+	t.Logf("t: %+v", t)
+
+	data := make(map[string]interface{})
+	data["contextName"] = "public"
+	data["endpoint"] = "127.0.0.1"
+	data["userName"] = "simulator"
+	data["privacyProtocol"] = "AES"
+	data["privacyPassphrase"] = "privatus"
+	data["port"] = 1024
+	data["authenticationProtocol"] = "SHA"
+	data["authenticationPassphrase"] = "auctoritas"
+	data["model"] = "Galaxy VM 180 kVA"
+	data["version"] = "v3"
+
+	galaxyUps, err := NewGalaxyUps(data)
+	assert.NoError(t, err)
+
+	// TODO: Need to do more with this, but at least exercises the code for now.
+	t.Logf("galaxyUps: %+v", galaxyUps)
+}
+
+// TestGalaxyUpsInitializationFailure tests that we get an error when we cannot initialize the UPS MIB.
+// This test uses a privacy failure to fail initialization.
+func TestGalaxyUpsInitializationFailure(t *testing.T) {
+	t.Log("TestGalaxyUpsInitializationFailure start")
+	t.Logf("t: %+v", t)
+
+	data := make(map[string]interface{})
+	data["contextName"] = "public"
+	data["endpoint"] = "127.0.0.1"
+	data["userName"] = "simulator"
+	data["privacyProtocol"] = "AES"
+	data["privacyPassphrase"] = "incorrect_password"
+	data["port"] = 1024
+	data["authenticationProtocol"] = "SHA"
+	data["authenticationPassphrase"] = "auctorias"
+	data["model"] = "Galaxy VM 180 kVA"
+	data["version"] = "v3"
+
+	_, err := NewGalaxyUps(data)
+	assert.Error(t, err)
+	assert.Equal(t, "Incoming packet is not authentic, discarding", err.Error())
+}

--- a/pkg/snmp/servers/snmp_server.go
+++ b/pkg/snmp/servers/snmp_server.go
@@ -1,0 +1,16 @@
+package servers
+
+import (
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-snmp-plugin/pkg/snmp/core"
+	mibs "github.com/vapor-ware/synse-snmp-plugin/pkg/snmp/mibs/ups_mib"
+)
+
+// SnmpServer is a base class for all SnmpServers.
+// This is meant to represnt any device serving SNMP.
+// Currently only the parts of the UPS-MIB are supported.
+type SnmpServer struct {
+	*core.SnmpServerBase                       // base class.
+	UpsMib               *mibs.UpsMib          // UpsMib is the only Mib currently supported. In the future this will be a slice or map of supported Mibs.
+	DeviceConfigs        []*config.DeviceProto // Enumerated device configs.
+}

--- a/pkg/snmp/servers/snmp_server_factory.go
+++ b/pkg/snmp/servers/snmp_server_factory.go
@@ -1,0 +1,34 @@
+package servers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CreateSnmpServer creates a SnmpServer from the configuration data model string.
+func CreateSnmpServer(data map[string]interface{}) (server *SnmpServer, err error) {
+	model, ok := data["model"].(string)
+	if !ok {
+		err = fmt.Errorf("No snmp server model")
+		return
+	}
+
+	// The model string comes from the configuration.
+	// The string itself is a prefix of what is returned from snmpget on OID .1.3.6.1.2.1.33.1.1.2.0
+	if strings.HasPrefix(model, "PXGMS UPS") {
+		var pxgmups *PxgmsUps
+		pxgmups, err = NewPxgmsUps(data)
+		server = pxgmups.SnmpServer
+		return
+	}
+
+	if strings.HasPrefix(model, "Galaxy VM") {
+		var galaxyups *GalaxyUps
+		galaxyups, err = NewGalaxyUps(data)
+		server = galaxyups.SnmpServer
+		return
+	}
+
+	err = fmt.Errorf("Unkown snmp server model: %v", model)
+	return
+}


### PR DESCRIPTION
Support the KE2-PIT/Northside VEM180a1 UPS.

Fixes https://github.com/vapor-ware/synse-snmp-plugin/issues/10