### PR TITLE
Update ci-shared to 1.0.3

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -2,7 +2,7 @@
 
 
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@master', retriever: modernSCM([
+library identifier: 'vapor@1.0.3', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',
@@ -11,36 +11,5 @@ library identifier: 'vapor@master', retriever: modernSCM([
 
 golangPipeline([
   'image': 'vaporio/snmp-plugin',
-  'podTemplate': """
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      labels:
-        jenkins/job: synse-snmp-plugin
-    spec:
-      containers:
-      - name: go
-        image: vaporio/jenkins-agent-golang:latest
-        command:
-        - cat
-        tty: true
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 998
-        volumeMounts:
-        - name: docker-sock
-          mountPath: /var/run/docker.sock
-        - name: docker-bin
-          mountPath: /usr/bin/docker
-      - name: emulator
-        image: lazypower/snmp-emulator:latest
-        tty: true
-      volumes:
-      - name: docker-sock
-        hostPath:
-          path: /var/run/docker.sock
-      - name: docker-bin
-        hostPath:
-          path: /usr/bin/docker
-  """,
+  'skipSetup': true,
 ])

--- a/.jenkins
+++ b/.jenkins
@@ -12,4 +12,8 @@ library identifier: 'vapor@1.0.3', retriever: modernSCM([
 golangPipeline([
   'image': 'vaporio/snmp-plugin',
   'skipSetup': true,
+  'skipUnitTest': true,
+  'emulators': [
+    'snmp',
+  ],
 ])

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ help:  ## Print usage information
 test: ## Run all tests
 	go test -cover ./... || exit
 
+.PHONY: unit-test
+unit-test: test
+
 
 # FIXME: try to streamline the below
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ help:  ## Print usage information
 test: ## Run all tests
 	go test -cover ./... || exit
 
-.PHONY: unit-test
+.PHONY: integration-test
 unit-test: test
 
 


### PR DESCRIPTION
- Aliased the test target to "integration-test" - as we need the emulator for those tests to pass.
- You no longer need to do UID/GID limbo for these tests :)