### PR TITLE
Version 2.1.3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := snmp
-PLUGIN_VERSION := 2.1.2
+PLUGIN_VERSION := 2.1.3
 IMAGE_NAME     := vaporio/snmp-plugin
 BIN_NAME       := synse-snmp-plugin
 

--- a/pkg/snmp/mibs/ups_mib/ups_alarms_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_alarms_table.go
@@ -11,7 +11,7 @@ import (
 // upsAlarmsInfo is what the device info will be under SNMP OID
 // .1.3.6.1.2.1.33.1.6.3 view it in a MIB browser to see the names.
 var upsAlarmsInfo = []string{
-	"upsAlarmBateryBad",
+	"upsAlarmBatteryBad",
 	"upsAlarmOnBattery",
 	"upsAlarmLowBattery",
 	"upsAlarmDepletedBattery",
@@ -148,7 +148,7 @@ func (enumerator UpsAlarmsTableDeviceEnumerator) DeviceEnumerator(
 		}
 
 		device = &config.DeviceInstance{
-			Info: fmt.Sprintf("upsAlarmTime%d", i),
+			Info: fmt.Sprintf("%sTime", upsAlarmsInfo[i]),
 			Data: deviceData,
 		}
 		statusProto.Instances = append(statusProto.Instances, device)

--- a/pkg/snmp/mibs/ups_mib/ups_alarms_table_test.go
+++ b/pkg/snmp/mibs/ups_mib/ups_alarms_table_test.go
@@ -13,7 +13,7 @@ import (
 func TestUpsAlarmsInfo(t *testing.T) {
 
 	var expected = []string{
-		"upsAlarmBateryBad",
+		"upsAlarmBatteryBad",
 		"upsAlarmOnBattery",
 		"upsAlarmLowBattery",
 		"upsAlarmDepletedBattery",


### PR DESCRIPTION
Emit Well Known Alarm Info Time in scan.
Fixes https://vaporio.atlassian.net/browse/VIO-1089.

Missed a column on the last PR. Sorry about this. Also found a tpyo - ugh.