### PR TITLE
Version 2.2.1. Support device tags to tell two UPSes apart.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := snmp
-PLUGIN_VERSION := 2.2.0
+PLUGIN_VERSION := 2.2.1
 IMAGE_NAME     := vaporio/snmp-plugin
 BIN_NAME       := synse-snmp-plugin
 

--- a/pkg/snmp/core/client_test.go
+++ b/pkg/snmp/core/client_test.go
@@ -25,7 +25,8 @@ func TestClient(t *testing.T) {
 		"127.0.0.1", // Endpoint
 		1024,        // Port
 		securityParameters,
-		"public", //  Context name
+		"public",   //  Context name
+		[]string{}, // tags (none)
 	)
 	assert.NoError(t, err)
 
@@ -283,7 +284,8 @@ func TestDeviceConfigSerialization(t *testing.T) {
 		"127.0.0.1", // Endpoint
 		1024,        // Port
 		securityParameters,
-		"public", //  Context name
+		"public",   //  Context name
+		[]string{}, // tags (none)
 	)
 	assert.NoError(t, err)
 

--- a/pkg/snmp/core/table_test.go
+++ b/pkg/snmp/core/table_test.go
@@ -29,7 +29,8 @@ func TestTable(t *testing.T) {
 		"127.0.0.1", // Endpoint
 		1024,        // Port
 		securityParameters,
-		"public", //  Context name
+		"public",   //  Context name
+		[]string{}, // tags (none)
 	)
 	assert.NoError(t, err)
 

--- a/pkg/snmp/mibs/ups_mib/ups_alarms_headers_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_alarms_headers_table.go
@@ -75,6 +75,7 @@ func (enumerator UpsAlarmsHeadersTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{

--- a/pkg/snmp/mibs/ups_mib/ups_alarms_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_alarms_table.go
@@ -107,6 +107,7 @@ func (enumerator UpsAlarmsTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{

--- a/pkg/snmp/mibs/ups_mib/ups_battery_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_battery_table.go
@@ -86,6 +86,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	voltageProto := &config.DeviceProto{
@@ -94,6 +95,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	currentProto := &config.DeviceProto{
@@ -102,6 +104,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	temperatureProto := &config.DeviceProto{
@@ -110,6 +113,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	percentageProto := &config.DeviceProto{
@@ -118,6 +122,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	minutesProto := &config.DeviceProto{
@@ -126,6 +131,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	secondsProto := &config.DeviceProto{
@@ -134,6 +140,7 @@ func (enumerator UpsBatteryTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{

--- a/pkg/snmp/mibs/ups_mib/ups_bypass_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_bypass_table.go
@@ -67,6 +67,11 @@ func (enumerator UpsBypassTableDeviceEnumerator) DeviceEnumerator(
 	mib := table.Mib.(*UpsMib)
 	model := mib.UpsIdentityTable.UpsIdentity.Model
 
+	snmpDeviceConfigMap, err := table.SnmpServerBase.DeviceConfig.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
 	// We will have "voltage", "current", and "power" device kinds.
 	// There is probably a better way of doing this, but this just gets things to
 	// where they need to be for now.
@@ -76,6 +81,7 @@ func (enumerator UpsBypassTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	currentProto := &config.DeviceProto{
@@ -84,6 +90,7 @@ func (enumerator UpsBypassTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	powerProto := &config.DeviceProto{
@@ -92,17 +99,13 @@ func (enumerator UpsBypassTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{
 		voltageProto,
 		currentProto,
 		powerProto,
-	}
-
-	snmpDeviceConfigMap, err := table.SnmpServerBase.DeviceConfig.ToMap()
-	if err != nil {
-		return nil, err
 	}
 
 	for i := 0; i < len(table.Rows); i++ {

--- a/pkg/snmp/mibs/ups_mib/ups_identity_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_identity_table.go
@@ -175,6 +175,7 @@ func (enumerator UpsIdentityTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{

--- a/pkg/snmp/mibs/ups_mib/ups_input_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_input_table.go
@@ -75,12 +75,14 @@ func (enumerator UpsInputTableDeviceEnumerator) DeviceEnumerator(
 	// We will have "frequency", "voltage", "current", and "power" device kinds.
 	// There is probably a better way of doing this, but this just gets things to
 	// where they need to be for now.
+	// TODO: Shim in the tags here.
 	frequencyProto := &config.DeviceProto{
 		Type: "frequency",
 		Context: map[string]string{
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	voltageProto := &config.DeviceProto{
@@ -89,6 +91,7 @@ func (enumerator UpsInputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	currentProto := &config.DeviceProto{
@@ -97,6 +100,7 @@ func (enumerator UpsInputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	powerProto := &config.DeviceProto{
@@ -105,6 +109,7 @@ func (enumerator UpsInputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{

--- a/pkg/snmp/mibs/ups_mib/ups_mib_test.go
+++ b/pkg/snmp/mibs/ups_mib/ups_mib_test.go
@@ -45,7 +45,8 @@ func TestUpsMib(t *testing.T) { // nolint: gocyclo
 		"127.0.0.1", // Endpoint
 		1024,        // Port
 		securityParameters,
-		"public", //  Context name
+		"public",   //  Context name
+		[]string{}, // tags (none)
 	)
 	assert.NoError(t, err)
 

--- a/pkg/snmp/mibs/ups_mib/ups_output_headers_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_output_headers_table.go
@@ -79,6 +79,7 @@ func (enumerator UpsOutputHeadersTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	frequencyProto := &config.DeviceProto{
@@ -87,6 +88,7 @@ func (enumerator UpsOutputHeadersTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{

--- a/pkg/snmp/mibs/ups_mib/ups_output_table.go
+++ b/pkg/snmp/mibs/ups_mib/ups_output_table.go
@@ -81,6 +81,7 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	voltageProto := &config.DeviceProto{
@@ -89,6 +90,7 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	currentProto := &config.DeviceProto{
@@ -97,6 +99,7 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	powerProto := &config.DeviceProto{
@@ -105,6 +108,7 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	percentageProto := &config.DeviceProto{
@@ -113,6 +117,7 @@ func (enumerator UpsOutputTableDeviceEnumerator) DeviceEnumerator(
 			"model": model,
 		},
 		Instances: []*config.DeviceInstance{},
+		Tags:      snmpDeviceConfigMap["deviceTags"].([]string),
 	}
 
 	devices = []*config.DeviceProto{


### PR DESCRIPTION
    config:
      deviceTags:
        - "serverName:customerUps"
        - "someTag:someThing"
        <etc>

This will allow a synse client to differentiate between the two UPSes on a VEM-20.