### PR TITLE
VIO-1911 Add config to make goreleaser use podman

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,7 @@ dockers:
       - docker.io/vaporio/snmp-plugin:{{ .Major }}.{{ .Minor }}
       - docker.io/vaporio/snmp-plugin:latest
     build_flag_templates:
+      - "--format docker"
       - "--label=org.label-schema.version={{ .Version }}"
       - "--label=org.label-schema.build-date={{ .Date }}"
       - "--label=org.label-schema.vcs-ref={{ .ShortCommit }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,8 @@ release:
   name_template: "{{ .Version }}"
 dockers:
   -
-    use: podman
+    # Need to use goreleaser Pro to get podman support
+    #use: podman
     goos: linux
     goarch: amd64
     image_templates:
@@ -40,7 +41,8 @@ dockers:
       - docker.io/vaporio/snmp-plugin:{{ .Major }}.{{ .Minor }}
       - docker.io/vaporio/snmp-plugin:latest
     build_flag_templates:
-      - "--format docker"
+      # Need to use goreleaser Pro to get podman support
+      #- "--format docker"
       - "--label=org.label-schema.version={{ .Version }}"
       - "--label=org.label-schema.build-date={{ .Date }}"
       - "--label=org.label-schema.vcs-ref={{ .ShortCommit }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,8 +34,6 @@ dockers:
     use: podman
     goos: linux
     goarch: amd64
-    binaries:
-      - synse-snmp-plugin
     image_templates:
       - docker.io/vaporio/snmp-plugin:{{ .Tag }}
       - docker.io/vaporio/snmp-plugin:{{ .Major }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,10 +36,10 @@ dockers:
     binaries:
       - synse-snmp-plugin
     image_templates:
-      - vaporio/snmp-plugin:{{ .Tag }}
-      - vaporio/snmp-plugin:{{ .Major }}
-      - vaporio/snmp-plugin:{{ .Major }}.{{ .Minor }}
-      - vaporio/snmp-plugin:latest
+      - docker.io/vaporio/snmp-plugin:{{ .Tag }}
+      - docker.io/vaporio/snmp-plugin:{{ .Major }}
+      - docker.io/vaporio/snmp-plugin:{{ .Major }}.{{ .Minor }}
+      - docker.io/vaporio/snmp-plugin:latest
     build_flag_templates:
       - "--label=org.label-schema.version={{ .Version }}"
       - "--label=org.label-schema.build-date={{ .Date }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ release:
   name_template: "{{ .Version }}"
 dockers:
   -
+    use: podman
     goos: linux
     goarch: amd64
     binaries:

--- a/.jenkins
+++ b/.jenkins
@@ -10,7 +10,7 @@ library identifier: 'vapor@1.19.7', retriever: modernSCM([
 
 
 golangPipeline([
-  'image': 'vaporio/snmp-plugin',
+  'image': 'docker.io/vaporio/snmp-plugin',
   'skipSetup': true,
   'skipUnitTest': true,
   'emulators': [

--- a/.jenkins
+++ b/.jenkins
@@ -2,7 +2,7 @@
 
 
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@1.19.7', retriever: modernSCM([
+library identifier: 'vapor@craig/VIO-1911', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder Image
 #
-FROM vaporio/foundation:bionic as builder
+FROM docker.io/vaporio/foundation:bionic as builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates
@@ -9,7 +9,7 @@ RUN apt-get update \
 #
 # Final Image
 #
-FROM vaporio/scratch-ish:1.0.0
+FROM docker.io/vaporio/scratch-ish:1.0.0
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.name="vaporio/snmp-plugin" \


### PR DESCRIPTION
This depends on changes I made to the golang Jenkins agent here:

https://github.com/vapor-ware/jenkins-agents/compare/73a50cec3dd84e525f88a52c6af613e0d9b03168...master

and to the `golangPipeline` here:

https://github.com/vapor-ware/ci-shared/pull/190/files