### PR TITLE
Fallback to non-bulk snmp walk on initial failure

### DIFF
--- a/pkg/snmp/servers/snmp_server_factory.go
+++ b/pkg/snmp/servers/snmp_server_factory.go
@@ -2,8 +2,8 @@ package servers
 
 import (
 	"fmt"
-	"strings"
 	log "github.com/sirupsen/logrus"
+	"strings"
 )
 
 // CreateSnmpServer creates a SnmpServer from the configuration data model string.
@@ -39,7 +39,7 @@ func CreateSnmpServer(data map[string]interface{}) (server *SnmpServer, err erro
 	if model == "SU10000RT3UPM" {
 		var trippliteups *TrippliteUps
 		trippliteups, err = NewTrippliteUps(data)
-		log.Debugf("Error is: [%s]", err)
+		log.Errorf("Error is: [%s]", err)
 		if err == nil {
 			server = trippliteups.SnmpServer
 			return


### PR DESCRIPTION
This PR implements a fallback on bulk requests to walk if bulk fails to receive a response. Without having access to server logs for this particular UPS/firmware, it is difficult to find the determine the reasons for timing out. The difference between `bulkwalk` and `walk` is the number of transactions (see https://www.mkssoftware.com/docs/man1/snmpbulkwalk.1.asp#:~:text=In%20contrast%20to%20snmpwalk%2C%20this,important%20when%20retrieving%20large%20tables.)

Downsides to this fallback approach is a larger number of synchronous requests traversing through the tree and waiting 90s for the initial timeout/retry cycle to populate tables.

Issue created for better testing moving forward: https://vaporio.atlassian.net/browse/VIO-2345

Logs:

```
DEBU[0000] [device manager] loading dynamic config...   
INFO[0000] [snmp] initializing UPS                      
DEBU[0000] model is: [SU10000RT3UPM]                    
INFO[0000] [snmp] loaded device config                   config="&{V3 10.193.19.242 cn1027 30s 3 0xc00031c300 161 [] 0}"
DEBU[0000] [snmp] created new SNMP client               
DEBU[0000] [snmp] created SNMP server base              
DEBU[0000] [snmp] initializing UpsMib                   
DEBU[0000] [snmp] creating new table                     name=UPS-MIB-UPS-Identity-Table oid=.1.3.6.1.2.1.33.1.1
DEBU[0000] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Identity-Table
DEBU[0120] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Identity-Table
DEBU[0120] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Identity-Table
DEBU[0120] [snmp] no row indexes when translating raw walk data 
WARN[0120] No identity information.                     
DEBU[0120] [snmp] creating new table                     name=UPS-MIB-UPS-Battery-Table oid=.1.3.6.1.2.1.33.1.2
DEBU[0120] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Battery-Table
DEBU[0121] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.2.1 2} {.1.3.6.1.2.1.33.1.2.2 0} {.1.3.6.1.2.1.33.1.2.3 455} {.1.3.6.1.2.1.33.1.2.4 100} {.1.3.6.1.2.1.33.1.2.5 2700} {.1.3.6.1.2.1.33.1.2.7 25}]" table=UPS-MIB-UPS-Battery-Table
DEBU[0121] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Battery-Table
DEBU[0121] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.2.%d.0 0xc0001cf6b0 [0xc0001c8900 0xc0001c8920 0xc0001c8960 0xc0001c89c0 0xc0001c89e0 0xc0001c8a00 0xc0001c8a20]}]" table=UPS-MIB-UPS-Battery-Table
DEBU[0121] [snmp] creating new table                     name=UPS-MIB-UPS-Input-Headers-Table oid=.1.3.6.1.2.1.33.1.3
DEBU[0121] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Input-Headers-Table
DEBU[0122] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.3.1 0} {.1.3.6.1.2.1.33.1.3.2 1} {.1.3.6.1.2.1.33.1.3.3.1.1.1 1} {.1.3.6.1.2.1.33.1.3.3.1.2.1 600} {.1.3.6.1.2.1.33.1.3.3.1.3.1 246}]" table=UPS-MIB-UPS-Input-Headers-Table
DEBU[0122] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Input-Headers-Table
DEBU[0122] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.3.%d.0 0xc0001cf760 [0xc000142400 0xc000142420]}]" table=UPS-MIB-UPS-Input-Headers-Table
DEBU[0122] [snmp] creating new table                     name=UPS-MIB-UPS-Input-Table oid=.1.3.6.1.2.1.33.1.3.3
DEBU[0122] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Input-Table
DEBU[0122] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.3.3.1.1.1 1} {.1.3.6.1.2.1.33.1.3.3.1.2.1 600} {.1.3.6.1.2.1.33.1.3.3.1.3.1 246}]" table=UPS-MIB-UPS-Input-Table
DEBU[0122] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Input-Table
DEBU[0122] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.3.3.1.%d.1 0xc0000bc000 [0xc000048300 0xc000048320 0xc000048340 0xc000142800 0xc000142820]}]" table=UPS-MIB-UPS-Input-Table
DEBU[0122] [snmp] creating new table                     name=UPS-MIB-UPS-Output-Headers-Table oid=.1.3.6.1.2.1.33.1.4
DEBU[0122] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Output-Headers-Table
DEBU[0123] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.4.1 3} {.1.3.6.1.2.1.33.1.4.2 600} {.1.3.6.1.2.1.33.1.4.3 1} {.1.3.6.1.2.1.33.1.4.4.1.1.1 1} {.1.3.6.1.2.1.33.1.4.4.1.2.1 208} {.1.3.6.1.2.1.33.1.4.4.1.3.1 0} {.1.3.6.1.2.1.33.1.4.4.1.4.1 0} {.1.3.6.1.2.1.33.1.4.4.1.5.1 0}]" table=UPS-MIB-UPS-Output-Headers-Table
DEBU[0123] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Output-Headers-Table
DEBU[0123] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.4.%d.0 0xc0000bc0b0 [0xc000142f40 0xc000142f60 0xc000142f80]}]" table=UPS-MIB-UPS-Output-Headers-Table
DEBU[0123] [snmp] creating new table                     name=UPS-MIB-UPS-Output-Table oid=.1.3.6.1.2.1.33.1.4.4
DEBU[0123] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Output-Table
DEBU[0124] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.4.4.1.1.1 1} {.1.3.6.1.2.1.33.1.4.4.1.2.1 208} {.1.3.6.1.2.1.33.1.4.4.1.3.1 0} {.1.3.6.1.2.1.33.1.4.4.1.4.1 0} {.1.3.6.1.2.1.33.1.4.4.1.5.1 0}]" table=UPS-MIB-UPS-Output-Table
DEBU[0124] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Output-Table
DEBU[0124] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.4.4.1.%d.1 0xc0000bc160 [0xc00054a000 0xc00054a020 0xc00054a040 0xc00054a060 0xc00054a080]}]" table=UPS-MIB-UPS-Output-Table
DEBU[0124] [snmp] creating new table                     name=UPS-MIB-UPS-Bypass-Headers-Table oid=.1.3.6.1.2.1.33.1.5
DEBU[0124] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Bypass-Headers-Table
DEBU[0125] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.5.1 600} {.1.3.6.1.2.1.33.1.5.2 1} {.1.3.6.1.2.1.33.1.5.3.1.1.1 1} {.1.3.6.1.2.1.33.1.5.3.1.2.1 245} {.1.3.6.1.2.1.33.1.5.3.1.3.1 0} {.1.3.6.1.2.1.33.1.5.3.1.4.1 0}]" table=UPS-MIB-UPS-Bypass-Headers-Table
DEBU[0125] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Bypass-Headers-Table
DEBU[0125] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.5.%d.0 0xc000558000 [0xc000532a40 0xc000532a60]}]" table=UPS-MIB-UPS-Bypass-Headers-Table
DEBU[0125] [snmp] creating new table                     name=UPS-MIB-UPS-Bypass-Table oid=.1.3.6.1.2.1.33.1.5.3
DEBU[0125] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Bypass-Table
DEBU[0126] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.5.3.1.1.1 1} {.1.3.6.1.2.1.33.1.5.3.1.2.1 245} {.1.3.6.1.2.1.33.1.5.3.1.3.1 0} {.1.3.6.1.2.1.33.1.5.3.1.4.1 0}]" table=UPS-MIB-UPS-Bypass-Table
DEBU[0126] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Bypass-Table
DEBU[0126] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.5.3.1.%d.1 0xc0005580b0 [0xc000210500 0xc000210520 0xc000210540 0xc000210560]}]" table=UPS-MIB-UPS-Bypass-Table
DEBU[0126] [snmp] creating new table                     name=UPS-MIB-UPS-Alarms-Headers-Table oid=.1.3.6.1.2.1.33.1.6
DEBU[0126] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Alarms-Headers-Table
DEBU[0126] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.6.1 0}]" table=UPS-MIB-UPS-Alarms-Headers-Table
DEBU[0126] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Alarms-Headers-Table
DEBU[0126] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.6.%d.0 0xc000558160 [0xc000533140]}]" table=UPS-MIB-UPS-Alarms-Headers-Table
DEBU[0126] [snmp] creating new table                     name=UPS-MIB-UPS-Alarms-Table oid=.1.3.6.1.2.1.33.1.6.2
DEBU[0126] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Alarms-Table
DEBU[0127] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Alarms-Table
DEBU[0127] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Alarms-Table
DEBU[0127] [snmp] no row indexes when translating raw walk data 
DEBU[0127] [snmp] creating new table                     name=UPS-MIB-UPS-Well-Known-Alarms-Table oid=.1.3.6.1.2.1.33.1.6.3
DEBU[0127] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Well-Known-Alarms-Table
DEBU[0127] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Well-Known-Alarms-Table
DEBU[0127] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Well-Known-Alarms-Table
DEBU[0127] [snmp] no row indexes when translating raw walk data 
DEBU[0127] [snmp] creating new table                     name=UPS-MIB-UPS-Test-Headers-Table oid=.1.3.6.1.2.1.33.1.7
DEBU[0127] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Test-Headers-Table
DEBU[0127] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.7.1 .1.3.6.1.2.1.33.1.7.7.1} {.1.3.6.1.2.1.33.1.7.3 1} {.1.3.6.1.2.1.33.1.7.4 Not test yet.}]" table=UPS-MIB-UPS-Test-Headers-Table
DEBU[0127] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Test-Headers-Table
DEBU[0127] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.7.%d.0 0xc000558370 [0xc0001433a0 0xc0001433c0 0xc0001433e0 0xc000143420 0xc000143440 0xc000143460]}]" table=UPS-MIB-UPS-Test-Headers-Table
DEBU[0127] [snmp] creating new table                     name=UPS-MIB-UPS-Well-Known-Tests-Table oid=.1.3.6.1.2.1.33.1.7.7
DEBU[0127] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Well-Known-Tests-Table
DEBU[0128] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Well-Known-Tests-Table
DEBU[0128] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Well-Known-Tests-Table
DEBU[0128] [snmp] no row indexes when translating raw walk data 
DEBU[0128] [snmp] creating new table                     name=UPS-MIB-UPS-Control-Table oid=.1.3.6.1.2.1.33.1.8
DEBU[0128] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Control-Table
DEBU[0129] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.8.1 1} {.1.3.6.1.2.1.33.1.8.2 0} {.1.3.6.1.2.1.33.1.8.3 -1} {.1.3.6.1.2.1.33.1.8.4 0} {.1.3.6.1.2.1.33.1.8.5 1}]" table=UPS-MIB-UPS-Control-Table
DEBU[0129] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Control-Table
DEBU[0129] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.8.%d.0 0xc0000bc2c0 [0xc000533a80 0xc000533aa0 0xc000533ac0 0xc000533b00 0xc000533b20]}]" table=UPS-MIB-UPS-Control-Table
DEBU[0129] [snmp] creating new table                     name=UPS-MIB-UPS-Config-Table oid=.1.3.6.1.2.1.33.1.9
DEBU[0129] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Config-Table
DEBU[0130] [snmp] got raw walk data                      data="[{.1.3.6.1.2.1.33.1.9.1 208} {.1.3.6.1.2.1.33.1.9.2 600} {.1.3.6.1.2.1.33.1.9.3 208} {.1.3.6.1.2.1.33.1.9.4 600} {.1.3.6.1.2.1.33.1.9.5 10000} {.1.3.6.1.2.1.33.1.9.8 1}]" table=UPS-MIB-UPS-Config-Table
DEBU[0130] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Config-Table
DEBU[0130] [snmp] finished translation of raw walk data into table rows  rows="[{.1.3.6.1.2.1.33.1.9.%d.0 0xc000558420 [0xc000143c40 0xc000143c60 0xc000143c80 0xc000143cc0 0xc000143ce0 0xc000143d00 0xc000143d20 0xc000143d40 0xc000143d60 0xc000143d80]}]" table=UPS-MIB-UPS-Config-Table
DEBU[0130] [snmp] creating new table                     name=UPS-MIB-UPS-Compliances-Table oid=.1.3.6.1.2.1.33.3.1
DEBU[0130] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Compliances-Table
DEBU[0130] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Compliances-Table
DEBU[0130] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Compliances-Table
DEBU[0130] [snmp] no row indexes when translating raw walk data 
DEBU[0130] [snmp] creating new table                     name=UPS-MIB-UPS-Subset-Groups-Table oid=.1.3.6.1.2.1.33.3.2.1
DEBU[0130] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Subset-Groups-Table
DEBU[0130] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Subset-Groups-Table
DEBU[0130] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Subset-Groups-Table
DEBU[0130] [snmp] no row indexes when translating raw walk data 
DEBU[0130] [snmp] creating new table                     name=UPS-MIB-UPS-Basic-Groups-Table oid=.1.3.6.1.2.1.33.3.2.2
DEBU[0130] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Basic-Groups-Table
DEBU[0131] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Basic-Groups-Table
DEBU[0131] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Basic-Groups-Table
DEBU[0131] [snmp] no row indexes when translating raw walk data 
DEBU[0131] [snmp] creating new table                     name=UPS-MIB-UPS-Full-Groups-Table oid=.1.3.6.1.2.1.33.3.2.3
DEBU[0131] [snmp] loading data from SNMP server          table=UPS-MIB-UPS-Full-Groups-Table
DEBU[0131] [snmp] got raw walk data                      data="[]" table=UPS-MIB-UPS-Full-Groups-Table
DEBU[0131] [snmp] starting translation of raw walk data into table rows  rows="[]" table=UPS-MIB-UPS-Full-Groups-Table
DEBU[0131] [snmp] no row indexes when translating raw walk data 
DEBU[0131] Initialized UpsMib                           
DEBU[0131] [snmp] created new UPS MIB                   
WARN[0131] [snmp] table has no rows, will not create any devices for it  oid=.1.3.6.1.2.1.33.1.1 table=UPS-MIB-UPS-Identity-Table
DEBU[0131] [snmp] enumerated the UPS MIB                 devices=23
DEBU[0131] [snmp] enumerated device                      device="&{status [] map[]  0s map[model:] [] [0xc0001a9b80]}"
DEBU[0131] [snmp] enumerated device                      device="&{voltage [] map[]  0s map[model:] [] [0xc0003be000]}"
DEBU[0131] [snmp] enumerated device                      device="&{current [] map[]  0s map[model:] [] [0xc0003be0a0]}"
DEBU[0131] [snmp] enumerated device                      device="&{temperature [] map[]  0s map[model:] [] [0xc0003be140]}"
DEBU[0131] [snmp] enumerated device                      device="&{percentage [] map[]  0s map[model:] [] [0xc0001a9f40]}"
DEBU[0131] [snmp] enumerated device                      device="&{minutes [] map[]  0s map[model:] [] [0xc0001a9e00]}"
DEBU[0131] [snmp] enumerated device                      device="&{seconds [] map[]  0s map[model:] [] [0xc0001a9cc0]}"
DEBU[0131] [snmp] enumerated device                      device="&{frequency [] map[]  0s map[model:] [] [0xc0003be1e0]}"
DEBU[0131] [snmp] enumerated device                      device="&{voltage [] map[]  0s map[model:] [] [0xc0003be280]}"
DEBU[0131] [snmp] enumerated device                      device="&{current [] map[]  0s map[model:] [] [0xc0003be320]}"
DEBU[0131] [snmp] enumerated device                      device="&{power [] map[]  0s map[model:] [] [0xc0003be3c0]}"
DEBU[0131] [snmp] enumerated device                      device="&{status [] map[]  0s map[model:] [] [0xc0003be460 0xc0003be5a0]}"
DEBU[0131] [snmp] enumerated device                      device="&{frequency [] map[]  0s map[model:] [] [0xc0003be500]}"
DEBU[0131] [snmp] enumerated device                      device="&{status [] map[]  0s map[model:] [] []}"
DEBU[0131] [snmp] enumerated device                      device="&{voltage [] map[]  0s map[model:] [] [0xc0003be640]}"
DEBU[0131] [snmp] enumerated device                      device="&{current [] map[]  0s map[model:] [] [0xc0003be6e0]}"
DEBU[0131] [snmp] enumerated device                      device="&{power [] map[]  0s map[model:] [] [0xc0003be780]}"
DEBU[0131] [snmp] enumerated device                      device="&{percentage [] map[]  0s map[model:] [] [0xc0003be820]}"
DEBU[0131] [snmp] enumerated device                      device="&{voltage [] map[]  0s map[model:] [] [0xc0003be8c0]}"
DEBU[0131] [snmp] enumerated device                      device="&{current [] map[]  0s map[model:] [] [0xc0003be960]}"
DEBU[0131] [snmp] enumerated device                      device="&{power [] map[]  0s map[model:] [] [0xc0003bea00]}"
DEBU[0131] [snmp] enumerated device                      device="&{status [] map[]  0s map[model:] [] [0xc0003beaa0]}"
DEBU[0131] [snmp] enumerated device                      device="&{status [] map[]  0s map[model:] [] []}"
```